### PR TITLE
Skip execution if the working copy is already a valid clone

### DIFF
--- a/scripts/codebuild-git-wrapper.sh
+++ b/scripts/codebuild-git-wrapper.sh
@@ -18,6 +18,13 @@ function usage {
   } >&2
 }
 
+# Skip if the working copy already has the .git directory.  This enables you to run your build under CodeBuild
+# Local for testing without change.
+if [[ -d .git ]]; then
+ echo "Working copy already has the .git directory so assuming this is already a valid clone.  Exiting"
+ exit 0
+fi 
+
 # Confirm that there are at least two arguments
 if [ "$#" -lt 1 ]; then
   usage


### PR DESCRIPTION
I found this script didn't work when running in CodeBuild Local because my working copy was already a valid clone.  Rather than temp hacks to the code or environment I've made a small addition to the script to check early on if there is a .git directory and exit cleanly if so.